### PR TITLE
new tag 0.9.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastuuid"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Omer Katz <omer.drow@gmail.com>"]
 license = "BSD3"
 description = "Python bindings to Rust's UUID library."


### PR DESCRIPTION
For push new wheels versions we should trigger our pipeline again and I think it's good idea to update the versions with it as well

It's for that update:

https://github.com/fastuuid/fastuuid/pull/32

