### PR TITLE
remove old python versions and fix pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,7 +16,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        exclude:
+          - os: macos-latest
+            python-version: '3.7'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -28,14 +31,17 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox==3.28.0 tox-gh-actions==2.12.0 tox-pyo3 maturin
       - name: Run tests
-        run: tox -vv
+        run: tox
   build:
     needs: test
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        exclude:
+          - os: macos-latest
+            python-version: '3.7'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -67,7 +73,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        exclude:
+          - os: macos-latest
+            python-version: '3.7'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,10 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
-        exclude:
-          - os: macos-latest
-            python-version: '3.7'
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -31,17 +28,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox==3.28.0 tox-gh-actions==2.12.0 tox-pyo3 maturin
       - name: Run tests
-        run: tox
+        run: tox -vv
   build:
     needs: test
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
-        exclude:
-          - os: macos-latest
-            python-version: '3.7'
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -73,10 +67,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
-        exclude:
-          - os: macos-latest
-            python-version: '3.7'
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,10 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
-        exclude:
-          - os: macos-latest
-            python-version: '3.7'
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -38,10 +35,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
-        exclude:
-          - os: macos-latest
-            python-version: '3.7'
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -73,10 +67,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
-        exclude:
-          - os: macos-latest
-            python-version: '3.7'
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastuuid"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Omer Katz <omer.drow@gmail.com>"]
 license = "BSD3"
 description = "Python bindings to Rust's UUID library."

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ FastUUID is a library which provides CPython bindings to Rust's UUID library.
 
 The provided API is exactly as Python's builtin UUID class.
 
-It is supported on Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, & 3.13.
+It is supported on Python 3.9, 3.10, 3.11, 3.12, & 3.13.
 
 Why?
 ----

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ FastUUID is a library which provides CPython bindings to Rust's UUID library.
 
 The provided API is exactly as Python's builtin UUID class.
 
-It is supported on Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, & 3.13.
+It is supported on Python 3.8, 3.9, 3.10, 3.11, 3.12, & 3.13.
 
 Why?
 ----

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ FastUUID is a library which provides CPython bindings to Rust's UUID library.
 
 The provided API is exactly as Python's builtin UUID class.
 
-It is supported on Python 3.9, 3.10, 3.11, 3.12, & 3.13.
+It is supported on Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, & 3.13.
 
 Why?
 ----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ multi_line_output = 3
 
 [project]
 name = "fastuuid"
+dynamic = ["version"]
 classifier = [
   "Development Status :: 4 - Beta",
   "License :: OSI Approved :: BSD License",
@@ -30,4 +31,4 @@ classifier = [
 maintainer = "Omer Katz"
 maintainer-email = "omer.drow@gmail.com"
 requires-python = ">=3.9"
-project-url = { homepage = "https://github.com/thedrow/fastuuid/" }
+urls = { homepage = "https://github.com/thedrow/fastuuid/" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ multi_line_output = 3
 
 [project]
 name = "fastuuid"
-dynamic = ["version"]
 classifier = [
   "Development Status :: 4 - Beta",
   "License :: OSI Approved :: BSD License",
@@ -19,6 +18,8 @@ classifier = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -30,5 +31,5 @@ classifier = [
 ]
 maintainer = "Omer Katz"
 maintainer-email = "omer.drow@gmail.com"
-requires-python = ">=3.9"
-urls = { homepage = "https://github.com/thedrow/fastuuid/" }
+requires-python = ">=3.7"
+project-url = { homepage = "https://github.com/thedrow/fastuuid/" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,6 @@ classifier = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -31,5 +29,5 @@ classifier = [
 ]
 maintainer = "Omer Katz"
 maintainer-email = "omer.drow@gmail.com"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 project-url = { homepage = "https://github.com/thedrow/fastuuid/" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ multi_line_output = 3
 
 [project]
 name = "fastuuid"
+dynamic = ["version"]
 classifier = [
   "Development Status :: 4 - Beta",
   "License :: OSI Approved :: BSD License",
@@ -32,4 +33,4 @@ classifier = [
 maintainer = "Omer Katz"
 maintainer-email = "omer.drow@gmail.com"
 requires-python = ">=3.7"
-project-url = { homepage = "https://github.com/thedrow/fastuuid/" }
+urls = { homepage = "https://github.com/thedrow/fastuuid/" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifier = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -32,5 +31,5 @@ classifier = [
 ]
 maintainer = "Omer Katz"
 maintainer-email = "omer.drow@gmail.com"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 urls = { homepage = "https://github.com/thedrow/fastuuid/" }

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,11 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, py38, py39, py310, py311, py312, py313, pypy3
+envlist = py38, py39, py310, py311, py312, py313, pypy3
 requires = tox-pyo3
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
@@ -17,7 +16,7 @@ python =
     3.12: py312
     3.13: py313
     pypy-3: pypy3
-    
+
 [testenv]
 pyo3 = True
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -4,17 +4,8 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py39, py310, py311, py312, py313, pypy3
+envlist = py37, py38, py39, py310, py311, py312, py313, pypy3
 requires = tox-pyo3
-
-[gh-actions]
-python =
-    3.9: py39
-    3.10: py310
-    3.11: py311
-    3.12: py312
-    3.13: py313
-    pypy-3: pypy3
 
 [testenv]
 pyo3 = True

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,17 @@
 envlist = py37, py38, py39, py310, py311, py312, py313, pypy3
 requires = tox-pyo3
 
+[gh-actions]
+python =
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311
+    3.12: py312
+    3.13: py313
+    pypy-3: pypy3
+    
 [testenv]
 pyo3 = True
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,17 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, py38, py39, py310, py311, py312, py313, pypy3
+envlist = py39, py310, py311, py312, py313, pypy3
 requires = tox-pyo3
+
+[gh-actions]
+python =
+    3.9: py39
+    3.10: py310
+    3.11: py311
+    3.12: py312
+    3.13: py313
+    pypy-3: pypy3
 
 [testenv]
 pyo3 = True


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f52676cd-b93f-4522-95e0-d3dff6c3efae)

Python 3.7 is not working on Ubuntu 24, I think it's fine to remove it, it's outdated

I have also added `gh-actions` section into `tox.ini` for mapping between tox python names definitions and github actions

It's for fix tests running

