### PR TITLE
List supported UUID versions in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ fastuuid
 
 FastUUID is a library which provides CPython bindings to Rust's UUID library.
 
-The provided API is exactly as Python's builtin UUID class.
+The provided API is exactly as Python's builtin UUID class. The supported UUID versions are v1, v3, v4, v5, and v7.
 
 It is supported on Python 3.8, 3.9, 3.10, 3.11, 3.12, & 3.13.
 


### PR DESCRIPTION
Just a small update to the readme to show which UUID versions are supported, based on [the features list in Cargo.toml](https://github.com/fastuuid/fastuuid/blob/master/Cargo.toml).

From reading through the README, it wasn't clear that v7 was supported, and [Python's current and next versions of the UUID module don't have v7 yet](https://docs.python.org/3.14/library/uuid.html).