### PR TITLE
Restore publishing source distribution to Pypi

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -50,7 +50,6 @@ jobs:
 
           - { os: windows-latest, target: x86_64, target-triple: x86_64-pc-windows-msvc, python-architecture: x64, auditwheel: check }
           - { os: windows-latest, target: i686,   target-triple: i686-pc-windows-msvc,   python-architecture: x86, auditwheel: check }
-
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
@@ -58,28 +57,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.conf.python-architecture }}
       - name: Build wheel
-        if: matrix.conf.auditwheel && matrix.conf.target
+        if: matrix.conf.target
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.conf.target }}
           manylinux: ${{ matrix.conf.manylinux }}
           # Auto-repair is only required for musl builds, otherwise it's check
           args: -i ${{ matrix.python-version }} --release --auditwheel ${{ matrix.conf.auditwheel }}
-      - name: Build wheels for older linux versions
-        if: matrix.conf.target == ''
-        # Build a wheel for the current python version in release mode
-        # When running on linux, use zig to build the oldest possible manylinux wheel
-        # In addition, check the wheel with auditwheel, but without auto-repair
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.conf.target }}
-          args: -i ${{ matrix.python-version }} --release --compatibility --zig --auditwheel check
-      - name: Build sdistx
-        if: matrix.conf.target == '' && matrix.python-version == '3.9'
-        run: maturin sdist
       - name: Display structure of built files
         run: ls -R target/wheels
-
       # Could use 'distro: alpine_latest' in 'run-on-arch-action' but seems difficult to install a specific version of python
       # so we'll just use existing python alpine images to test import and cli use w/o testing archs other than x86_64
       - name: Install built wheel and Test (musllinux)
@@ -99,13 +85,36 @@ jobs:
           # use first to get in dev dependencies
           python -m pip install fastuuid --find-links target/wheels --force-reinstall
           python -c "import fastuuid; print('Package imported successfully')"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install maturin[zig] twine
       - name: Publish to PyPI
         if: github.event_name == 'push' && contains(github.ref, '.')
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: twine upload target/wheels/*
+        run: |
+          python -m pip install --upgrade pip
+          pip install twine
+          twine upload target/wheels/*
+  build-sdist:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.9
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: ''
+          args: sdist
+      - name: Display structure of built files
+        run: ls -R target/wheels
+      - name: Publish to PyPI
+        if: github.event_name == 'push' && contains(github.ref, '.')
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install twine
+          twine upload target/wheels/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ multi_line_output = 3
 
 [project]
 name = "fastuuid"
+description = "Python bindings to Rust's UUID library."
 dynamic = ["version"]
 classifiers = [
   "Development Status :: 4 - Beta",


### PR DESCRIPTION
Restore workflow for building sdist, remove older linux versions step. Sorry purpose of this line wasn't very clear

This was deleted in 743a21f8, but sdist has disappeared from pypi https://pypi.org/project/fastuuid/#files